### PR TITLE
Fix spurious test failures in tests of functions that encode protobuf

### DIFF
--- a/cmd/controlplane/cluster_test.go
+++ b/cmd/controlplane/cluster_test.go
@@ -10,7 +10,6 @@ import (
 	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoyExtensionsUpstreams "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	envoyType "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/protobuf/runtime/protoiface"
@@ -139,7 +138,7 @@ func Test_buildEnvoyClusterConfig(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.buildEnvoyClusterConfig(test.cluster), test.name)
 	}
 }
@@ -174,7 +173,7 @@ func Test_clusterConnectTimeout(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterConnectTimeout(test.cluster), test.name)
 	}
 }
@@ -259,7 +258,7 @@ func Test_clusterLbPolicy(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterLbPolicy(test.cluster), test.name)
 	}
 }
@@ -343,7 +342,7 @@ func Test_clusterLoadAssignment(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterLoadAssignment(test.cluster), test.name)
 	}
 }
@@ -431,7 +430,7 @@ func Test_clusterCircuitBreakers(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterCircuitBreakers(test.cluster), test.name)
 	}
 }
@@ -511,7 +510,7 @@ func Test_clusterHealthChecks(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterHealthChecks(test.cluster), test.name)
 	}
 }
@@ -570,7 +569,7 @@ func Test_clusterHealthCodec(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterHealthCodec(test.cluster), test.name)
 	}
 }
@@ -621,7 +620,7 @@ func Test_clusterTransportSocket(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterTransportSocket(test.cluster), test.name)
 	}
 }
@@ -684,7 +683,7 @@ func Test_clusterSNIHostname(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterSNIHostname(test.cluster), test.name)
 	}
 }
@@ -736,7 +735,7 @@ func Test_clusterDNSLookupFamily(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterDNSLookupFamily(test.cluster), test.name)
 	}
 }
@@ -771,7 +770,7 @@ func Test_clusterDNSRefreshRate(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterDNSRefreshRate(test.cluster), test.name)
 	}
 }
@@ -855,7 +854,7 @@ func Test_clusterDNSResolvers(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterDNSResolvers(test.cluster), test.name)
 	}
 }
@@ -977,7 +976,7 @@ func Test_clusterTypedExtensionProtocolOptions(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.clusterTypedExtensionProtocolOptions(test.cluster), test.name)
 	}
 }

--- a/cmd/controlplane/common_test.go
+++ b/cmd/controlplane/common_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -283,9 +284,7 @@ func Test_buildCommonTLSContext(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		// log.Printf("# %+v\n", test.expected)
-		// log.Printf("# %+v\n", buildCommonTLSContext(test.resourceName, test.attributes))
-		RequireEqual(t, test.expected, buildCommonTLSContext(test.resourceName, test.attributes))
+		equal(t, test.expected, buildCommonTLSContext(test.resourceName, test.attributes))
 	}
 }
 
@@ -548,13 +547,22 @@ func mustMarshalAny(src protoreflect.ProtoMessage) *anypb.Any {
 	return a
 }
 
-// RequireEqual will test that want == got for protobufs, call t.fatal if it does not,
-// This mimics the behavior of the testify `require` functions.
-func RequireEqual(t *testing.T, want, got interface{}) {
+// equal will test that want == got for protobufs, call t.fatal if it does not,
+// This mimics the behavior of the testify `require.Equal` function.
+func equal(t *testing.T, want, got interface{}) {
+	equalf(t, want, got, "")
+}
+
+// equalf will test that want == got for protobufs, call t.fatal if it does not,
+// This mimics the behavior of the testify `require.EqualF` function.
+func equalf(t *testing.T, want, got interface{}, msg string, args ...interface{}) {
 	t.Helper()
 
 	diff := cmp.Diff(want, got, protocmp.Transform())
 	if diff != "" {
-		t.Fatal(diff)
+		t.Errorf(fmt.Sprintf("Not equal:\n"+
+			"Delta: %s\n"+
+			"Additional data: %s", diff, msg), args...)
+		t.FailNow()
 	}
 }

--- a/cmd/controlplane/listener_test.go
+++ b/cmd/controlplane/listener_test.go
@@ -13,7 +13,6 @@ import (
 	ratelimit "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ratelimit/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -44,7 +43,7 @@ func Test_buildConnectionManager(t *testing.T) {
 		ServerName:                "QWERTY",
 	}
 
-	require.Equalf(t, expected1,
+	equalf(t, expected1,
 		s.buildConnectionManager(listener1), "test1")
 }
 
@@ -287,7 +286,7 @@ func Test_buildFilter(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			test.s.buildFilter(test.listener), test.name)
 	}
 }
@@ -353,7 +352,7 @@ func Test_buildHTTPFilterExtAuthzConfig(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			test.s.buildHTTPFilterExtAuthzConfig(test.listener), test.name)
 	}
 }
@@ -413,7 +412,7 @@ func Test_buildRouteSpecifierRDS(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			test.s.buildRouteSpecifierRDS(test.routeGroup), test.name)
 	}
 }
@@ -468,10 +467,7 @@ func Test_buildAccessLog(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		RequireEqual(t, test.expected,
-			s.buildAccessLog(test.listener))
-		// require.Equalf(t, test.expected,
-		// 	buildAccessLog(test.listener), test.name)
+		equal(t, test.expected, s.buildAccessLog(test.listener))
 	}
 }
 
@@ -526,8 +522,7 @@ func Test_buildFileAccessLog(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		RequireEqual(t, test.expected,
-			s.buildFileAccessLog(test.path, test.fields))
+		equal(t, test.expected, s.buildFileAccessLog(test.path, test.fields))
 	}
 }
 
@@ -566,7 +561,7 @@ func Test_buildGRPCAccessLog(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.buildGRPCAccessLog(test.clusterName, test.logName,
 				test.timeout, test.bufferSize), test.name)
 	}
@@ -604,7 +599,7 @@ func Test_buildCommonHTTPProtocolOptions(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			listenerCommonHTTPProtocolOptions(test.listener), test.name)
 	}
 }
@@ -654,7 +649,7 @@ func Test_buildHTTP2ProtocolOptions(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			buildHTTP2ProtocolOptions(test.listener), test.name)
 	}
 }

--- a/cmd/controlplane/route_test.go
+++ b/cmd/controlplane/route_test.go
@@ -11,7 +11,6 @@ import (
 	envoy_matcher "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -244,7 +243,7 @@ func Test_buildEnvoyRoute(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.buildEnvoyRoutes(test.RouteGroup, test.routes), test.name)
 	}
 }
@@ -301,8 +300,7 @@ func Test_buildRouteMatch(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
-			buildRouteMatch(test.route), test.name)
+		equalf(t, test.expected, buildRouteMatch(test.route), test.name)
 	}
 }
 
@@ -404,7 +402,7 @@ func Test_buildWeightedClusters(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.buildWeightedClusters(test.route), test.name)
 	}
 }
@@ -511,7 +509,7 @@ func Test_buildRequestMirrorPolicies(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.buildRequestMirrorPolicies(test.route), test.name)
 	}
 }
@@ -610,7 +608,7 @@ func Test_buildCorsPolicy(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			buildCorsPolicy(test.route), test.name)
 	}
 }
@@ -684,7 +682,7 @@ func Test_buildRouteActionDirectResponse(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			buildRouteActionDirectResponse(test.route), test.name)
 	}
 }
@@ -821,7 +819,7 @@ func Test_buildRouteActionRedirectResponse(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.buildRouteActionRedirectResponse(test.route), test.name)
 	}
 }
@@ -890,7 +888,7 @@ func Test_buildUpstreamHeadersToAdd(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			buildUpstreamHeadersToAdd(test.route), test.name)
 	}
 }
@@ -939,7 +937,7 @@ func Test_buildUpstreamHeadersToRemove(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			buildUpstreamHeadersToRemove(test.route), test.name)
 	}
 }
@@ -972,7 +970,7 @@ func Test_buildHeadersList(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			buildHeadersList(test.headers), test.name)
 	}
 }
@@ -1066,7 +1064,7 @@ func Test_buildRetryPolicy(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			buildRetryPolicy(test.route), test.name)
 	}
 }
@@ -1095,7 +1093,7 @@ func Test_buildStatusCodesSlice(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			buildStatusCodesSlice(test.statusCodes), test.name)
 	}
 }
@@ -1139,7 +1137,7 @@ func Test_buildPerRouteFilterConfig(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			buildPerRouteFilterConfig(test.route), test.name)
 	}
 }
@@ -1192,7 +1190,7 @@ func Test_perRouteAuthzFilterConfig(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			perRouteAuthzFilterConfig(test.route), test.name)
 	}
 }
@@ -1247,7 +1245,7 @@ func Test_buildEnvoyVirtualClusters(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			s.buildEnvoyVirtualClusters(test.RouteGroup, test.routes), test.name)
 	}
 }
@@ -1309,7 +1307,7 @@ func Test_buildEnvoyVirtualClusterPathMatch(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		require.Equalf(t, test.expected,
+		equalf(t, test.expected,
 			buildEnvoyVirtualClusterPathMatch(test.route), test.name)
 	}
 }


### PR DESCRIPTION
Workaround for https://github.com/stretchr/testify/issues/758: require.Equal() does not always return true when to proto messages are equal, which results in spurious test failures in functions that encode protobuf.